### PR TITLE
chore: add a command to determine if a monorepo subpath has changed between commits

### DIFF
--- a/cmd/scm/scm.go
+++ b/cmd/scm/scm.go
@@ -69,6 +69,7 @@ func init() {
 	RootCmd.AddCommand(cmd.NewURLCmd())
 	RootCmd.AddCommand(cmd.NewTokenCmd())
 	RootCmd.AddCommand(cmd.NewPrCmd())
+	RootCmd.AddCommand(cmd.NewMonoRepoChangeCmd())
 
 	RootCmd.PersistentPreRun = func(command *cobra.Command, args []string) {
 		if Verbose {

--- a/docs/scm.md
+++ b/docs/scm.md
@@ -16,6 +16,7 @@ a CLI used to interact with different scm providers
 
 ### SEE ALSO
 
+* [scm monorepo-change](scm_monorepo-change.md)	 - Determines the sha to clone for the supplied path on the monorepository
 * [scm pr](scm_pr.md)	 - 
 * [scm token](scm_token.md)	 - Determines the token to use for an scm provider
 * [scm url](scm_url.md)	 - Calculates the url for an scm provider

--- a/docs/scm_monorepo-change.md
+++ b/docs/scm_monorepo-change.md
@@ -1,0 +1,38 @@
+## scm monorepo-change
+
+Determines the sha to clone for the supplied path on the monorepository
+
+```
+scm monorepo-change [flags]
+```
+
+### Examples
+
+```
+scm monorepo-change --host=https://github.com --path .git-credentials
+```
+
+### Options
+
+```
+      --branch string            The branch to search on (default: main) (default "main")
+      --host string              The host of the scm provider, including scheme
+  -k, --kind string              The kind of the scm provider
+  -o, --owner string             The owner of the repository
+  -p, --path string              The path to the git-credentials file
+      --previous-commit string   The previous commit to search from (optional)
+  -r, --repo string              The name of the repository
+      --subpath string           The subPath to look for changes in (default: "")
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --debug   Debug Output
+      --help    Show help for command
+```
+
+### SEE ALSO
+
+* [scm](scm.md)	 - provides commands for interacting with different scm providers
+

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -2,9 +2,10 @@ package client
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"net/url"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/factory"

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"net/url"
 	"strings"
 
@@ -24,11 +25,12 @@ func FromRepoURL(repoURL string, credentials string, kind string) (*scm.Client, 
 		auth = password
 		username = u.User.Username()
 	} else {
-		fmt.Println("[DEBUG] Token is not available from the url, falling back to .git-credentials")
+		logrus.Debugf("Token is not available from the url, falling back to .git-credentials")
 		user, token, err := DetermineAuth(credentials, repoURL)
 		if err != nil {
 			return nil, "", "", err
 		}
+		logrus.Debugf("Got auth from .git-credentials")
 		auth = token
 		username = user
 	}

--- a/pkg/cmd/monorepo.go
+++ b/pkg/cmd/monorepo.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"os"
-	"strings"
 )
 
 var (

--- a/pkg/cmd/monorepo.go
+++ b/pkg/cmd/monorepo.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/jenkins-x/go-scm/scm"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+)
+
+var (
+	PreviousCommit string
+	Branch         string
+	SubPath        string
+)
+
+// NewMonoRepoChangeCmd creates a new token command.
+func NewMonoRepoChangeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "monorepo-change",
+		Short:   "Determines the sha to clone for the supplied path on the monorepository",
+		Long:    "",
+		Example: "scm monorepo-change --host=https://github.com --path .git-credentials",
+		Aliases: []string{"t"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			b, err := os.ReadFile(Path)
+			if err != nil {
+				return err
+			}
+			token, err := DetermineMonoRepoChange(string(b), Kind, Host, Owner, Repo)
+			if err != nil {
+				return err
+			}
+			fmt.Fprint(cmd.OutOrStdout(), token)
+			return nil
+		},
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+	}
+
+	// common flags
+	cmd.Flags().StringVarP(&Path, "path", "p", "", "The path to the git-credentials file")
+	cmd.Flags().StringVarP(&Host, "host", "", "", "The host of the scm provider, including scheme")
+	cmd.Flags().StringVarP(&Owner, "owner", "o", "", "The owner of the repository")
+	cmd.Flags().StringVarP(&Repo, "repo", "r", "", "The name of the repository")
+	cmd.Flags().StringVarP(&Kind, "kind", "k", "", "The kind of the scm provider")
+
+	// local flags
+	cmd.Flags().StringVarP(&PreviousCommit, "previous-commit", "", "", "The previous commit to search from (optional)")
+	cmd.Flags().StringVarP(&Branch, "branch", "", "main", "The branch to search on (default: main)")
+	cmd.Flags().StringVarP(&SubPath, "subpath", "", "", "The subPath to look for changes in (default: \"\")")
+
+	_ = cobra.MarkFlagRequired(cmd.Flags(), "path")
+	_ = cobra.MarkFlagRequired(cmd.Flags(), "host")
+	_ = cobra.MarkFlagRequired(cmd.Flags(), "owner")
+	_ = cobra.MarkFlagRequired(cmd.Flags(), "repo")
+
+	return cmd
+}
+
+func DetermineMonoRepoChange(credentials string, kind string, host string, owner string, repo string) (string, error) {
+	repositoryURL := GetURL(kind, host, owner, repo)
+
+	scmClient, _, _, err := GetScmClient(repositoryURL)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to create scm client")
+	}
+
+	return DetermineClonePoint(scmClient, fmt.Sprintf("%s/%s", owner, repo), Branch, PreviousCommit, SubPath)
+}
+
+func DetermineClonePoint(client *scm.Client, repository string, branch string, previousCommit string, subPath string) (string, error) {
+	ctx := context.Background()
+
+	logrus.Debugf("previousCommit=%s\n", previousCommit)
+	logrus.Debugf("repository=%s\n", repository)
+
+	ref, _, err := client.Git.FindBranch(ctx, repository, branch)
+	if err != nil {
+		return "", err
+	}
+
+	logrus.Debugf("latest commit on branch is %s, ref=%+v\n", branch, ref)
+
+	latestCommitOnBranch := ref.Sha
+
+	// this is the first time we are seeing this repository, so we need to clone it all
+	if previousCommit == "" {
+		return latestCommitOnBranch, nil
+	}
+
+	// our understanding of the repository is up to date, so there is no work to be done
+	if latestCommitOnBranch == previousCommit {
+		return previousCommit, nil
+	}
+
+	// if subPath is not set, we want the whole repository
+	if subPath == "" {
+		return latestCommitOnBranch, nil
+	}
+
+	changes, _, err := client.Git.CompareCommits(ctx, repository, previousCommit, latestCommitOnBranch, &scm.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	logrus.Debugf("checking %d changes", len(changes))
+
+	for _, change := range changes {
+		logrus.Debugf("%s", change.Path)
+		if strings.HasPrefix(change.Path, subPath) {
+			return latestCommitOnBranch, nil
+		}
+	}
+
+	return previousCommit, nil
+}


### PR DESCRIPTION
```shell
❯ scm monorepo-change \
        --host https://github.com \
        --owner garethjevans \
        --repo monorepository-controller \
        --path ~/fake-git-credentials \
        --previous-commit c85a5275030d54543dac63568fd182e726f5e68e \
        --subpath internal
7cfc722fc153a4dbd61bc01ae7ec6c8d620cbfed
```